### PR TITLE
Fixed active class bug in header

### DIFF
--- a/views/partials/header.pug
+++ b/views/partials/header.pug
@@ -8,7 +8,7 @@
       span.navbar-toggler-icon
     .collapse.navbar-collapse
       ul.nav.navbar-nav
-        li.active.nav-item(class=(title === 'Home') ? 'active' : undefined)
+        li.nav-item(class=(title === 'Home') ? 'active' : undefined)
           a.nav-link(href='/') Home
         li.nav-item(class=(title === 'API Examples') ? 'active' : undefined)
           a.nav-link(href='/api') API Examples


### PR DESCRIPTION
Fixed a bug on the Home link's active class introduced by Bootstrap 4.